### PR TITLE
Handle failed deserializations

### DIFF
--- a/src/Message/Serializer/DocplannerEnvelopeSerializer.php
+++ b/src/Message/Serializer/DocplannerEnvelopeSerializer.php
@@ -44,9 +44,13 @@ final class DocplannerEnvelopeSerializer implements SerializerInterface
 		$body   = $encodedEnvelope['body'];
 		$stamps = $this->decodeStamps($encodedEnvelope);
 
-		/** @var DocplannerEnvelope $docplannerEnvelope */
-		$docplannerEnvelope = $this->serializer->deserialize($body, DocplannerEnvelope::class, 'json');
-		$message            = $this->mappingAwareSerializer->deserialize($docplannerEnvelope);
+        try {
+            /** @var DocplannerEnvelope $docplannerEnvelope */
+            $docplannerEnvelope = $this->serializer->deserialize($body, DocplannerEnvelope::class, 'json');
+            $message            = $this->mappingAwareSerializer->deserialize($docplannerEnvelope);
+        } catch (UnexpectedValueException $e) {
+            throw new MessageDecodingFailedException(sprintf('Could not decode message: %s.', $e->getMessage()), $e->getCode(), $e);
+        }
 
 		return new Envelope($message, $stamps);
 	}


### PR DESCRIPTION
We should catch failed tries of deserialization (just like[ in default Serializer](https://github.com/symfony/messenger/blob/4.4/Transport/Serialization/Serializer.php#L80-L84)). It allows [drop wrong message](https://github.com/symfony/messenger/blob/4.4/Transport/AmqpExt/AmqpReceiver.php#L68-L73) from the queue.