### PR TITLE
change AmqpStamp use in RoutingKeyMiddleware.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@ Configuration:
 messenger.bridge.routing.app_id_routing_key_resolver:
     class: DanielKorytek\MessengerBridgeBundle\Message\Routing\RoutingKeyResolver\AppIdRoutingKeyResolver
 
+Symfony < 5.1
 messenger.bridge.middleware.routing_key:
     class: DanielKorytek\MessengerBridgeBundle\Middleware\RoutingKeyMiddleware
+    arguments:
+      - '@messenger.bridge.routing.app_id_routing_key_resolver'
+    tags:
+      - { name: messenger.middleware }
+
+Symfony >= 5.1
+
+messenger.bridge.middleware.routing_key:
+    class: DanielKorytek\MessengerBridgeBundle\Middleware\Symf51\RoutingKeyMiddleware
     arguments:
       - '@messenger.bridge.routing.app_id_routing_key_resolver'
     tags:

--- a/src/Middleware/RoutingKeyMiddleware.php
+++ b/src/Middleware/RoutingKeyMiddleware.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
-use Symfony\Component\Messenger\Transport\AmqpExt\AmqpStamp;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpStamp;
 
 final class RoutingKeyMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/Symf51/RoutingKeyMiddleware.php
+++ b/src/Middleware/Symf51/RoutingKeyMiddleware.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DanielKorytek\MessengerBridgeBundle\Middleware;
+namespace DanielKorytek\MessengerBridgeBundle\Middleware\Symf51;
 
 
 use DanielKorytek\MessengerBridgeBundle\Exception\UnsupportedMessage;
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
-use Symfony\Component\Messenger\Transport\AmqpExt\AmqpStamp;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpStamp;
 
 final class RoutingKeyMiddleware implements MiddlewareInterface
 {


### PR DESCRIPTION
Change because of following deprecation notice

`  1x: Since symfony/messenger 5.1: The "Symfony\Component\Messenger\Transport\AmqpExt\AmqpStamp" class is deprecated, use "Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpStamp" instead. The AmqpExt transport has been moved to package "symfony/amqp-messenger" and will not be included by default in 6.0. Run "composer require symfony/amqp-messenger".`

Tested in docplanner widgets app