### PR TITLE
remove indentation for exchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ framework:
                         incoming_events: #your queue name (here yours app receives messages from other apps via exchange)
                             binding_keys:
                                 - "%locale%.app-name.smth.changed" #routing key binding list
-                            exchange:
-                                name: "%env(MESSENGER_SHARED_INCOMING_EXCHANGE_NAME)%" #incoming exchange name
-                                type: topic
+                    exchange:
+                        name: "%env(MESSENGER_SHARED_INCOMING_EXCHANGE_NAME)%" #incoming exchange name
+                        type: topic
 ```
 
 ### Messages


### PR DESCRIPTION
after comparing readme config with config in working app I found out that  'exchange' key is indented too far i readme