### PR TITLE
add BusStampEnvelopeSerializer.php and change README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Configuration:
 
 - Register middleware
 
- ```
+ ```yaml
 messenger.bridge.routing.app_id_routing_key_resolver:
     class: DanielKorytek\MessengerBridgeBundle\Message\Routing\RoutingKeyResolver\AppIdRoutingKeyResolver
 
@@ -28,7 +28,7 @@ In `messenger.yml` put `messenger.bridge.middleware.routing_key` to your bus mid
 
 Example:
 
-```
+```yaml
 framework:
        messenger:
            default_bus: command.bus
@@ -47,7 +47,7 @@ To endure adequate possibility for serialization/deserialization process, you ne
 
 Required serializer configuration:
 
-```
+```yaml
 services:
     serializer.property.normalizer:
         class: Symfony\Component\Serializer\Normalizer\PropertyNormalizer
@@ -75,7 +75,7 @@ services:
 
 ### Bus example configuration
 
-```
+```yaml
 framework:
     messenger:
         #your other buses here
@@ -130,11 +130,22 @@ All messages representation classes `HAVE TO` implement `NamedMessageInterface`.
 
 ### Subscribing 
 
+- Register serializer for external messages
+```yaml
+services:
+
+  messenger.bridge.bus_stamp_docplanner.serializer:
+    class: DanielKorytek\MessengerBridgeBundle\Message\Serializer\BusStampEnvelopeSerializer
+    arguments:
+      - '@messenger.bridge.serializer' #docplanner SEB  messages serializer
+      - 'shared.message.bus' #bus name from messenger configuration
+```
+
 - Add message binding key in your incoming transport:
 This step is for messenger command. If you're using different package, you should update config in proper place.
-```
+```yaml
  incoming:
-    serializer: messenger.bridge.serializer
+    serializer: messenger.bridge.bus_stamp_docplanner.serializer 
     dsn: "%env(MESSENGER_TRANSPORT_DSN)%"
     options:
         queues:
@@ -142,20 +153,20 @@ This step is for messenger command. If you're using different package, you shoul
                 binding_keys:
                     - "%locale%.app-name.smth.changed"
                     - "%locale%.app-name.smth"  #new key
-                exchange:
-                    name: "%env(MESSENGER_SHARED_INCOMING_EXCHANGE_NAME)%" #incoming exchange name
-                    type: topic
+        exchange:
+            name: "%env(MESSENGER_SHARED_INCOMING_EXCHANGE_NAME)%" #incoming exchange name
+            type: topic
 ```
 - Create representation class for a message.
 - Attach message mapping to `messenger.bridge.subscriber_events_mapping` parameter:
 
-```
+```yaml
 messenger.bridge.subscriber_events_mapping:
     app-name.smth.changed: App\Namespace\MessageClass
 ```
-- Create subscriber class and bind with correct bus: 
+- Create subscriber class and bind with correct bus:
 
-```
+```php
 <?php
 
 declare(strict_types=1);
@@ -183,3 +194,4 @@ class SaasAttendanceSubscriber implements MessageSubscriberInterface
 }
 
 ```
+

--- a/src/Message/Serializer/BusStampEnvelopeSerializer.php
+++ b/src/Message/Serializer/BusStampEnvelopeSerializer.php
@@ -15,6 +15,9 @@ final class BusStampEnvelopeSerializer implements SerializerInterface
      */
     private $serializer;
 
+    /**
+     * @var string
+     */
     private $busName;
 
     public function __construct(SerializerInterface $serializer, string $busName)

--- a/src/Message/Serializer/BusStampEnvelopeSerializer.php
+++ b/src/Message/Serializer/BusStampEnvelopeSerializer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DanielKorytek\MessengerBridgeBundle\Message\Serializer;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+final class BusStampEnvelopeSerializer implements SerializerInterface
+{
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    private $busName;
+
+    public function __construct(SerializerInterface $serializer, string $busName)
+    {
+        $this->serializer = $serializer;
+        $this->busName = $busName;
+    }
+
+    public function decode(array $encodedEnvelope): Envelope
+    {
+        $envelope = $this->serializer->decode($encodedEnvelope);
+
+        $envelope = $envelope->with(new BusNameStamp($this->busName));
+
+        return $envelope;
+    }
+
+    public function encode(Envelope $envelope): array
+    {
+        return $this->serializer->encode($envelope);
+    }
+}


### PR DESCRIPTION
Adding BusStamp tu envelope is necessary when
- we have multiple busses in our messanger
- external bus is not default one.

Normally BusStamp is added by messenger. But external messages don't have one. So if not specify our default one will be used. It could cause problems with middlewares because probably we will different middlewares on internal and external busses