### PR TITLE
use interface instead of class in DocplannerEnvelopeSerializer.php se…

### DIFF
--- a/src/Message/Serializer/DocplannerEnvelopeSerializer.php
+++ b/src/Message/Serializer/DocplannerEnvelopeSerializer.php
@@ -28,7 +28,7 @@ final class DocplannerEnvelopeSerializer implements SerializerInterface
 	 */
 	private $serializer;
 
-	public function __construct(MappingAwareSerializer $mappingAwareSerializer, SymfonySerializerInterface $serializer)
+	public function __construct(MappingAwareSerializerInterface $mappingAwareSerializer, SymfonySerializerInterface $serializer)
 	{
 		$this->serializer             = $serializer;
 		$this->mappingAwareSerializer = $mappingAwareSerializer;


### PR DESCRIPTION
I need to use JmsSerializer instead of Symfony serializer in MappingAwareSerializer, because Symfony serializer has troubles with deserializing from json with snake_case to class with camelCase properties.

To do it safely by overwriting MappingAwareSerializer I could use this small change with interface required in constructo. It shouldn't affect anything