### PR TITLE
Compatibility with Symfony 6 fix, missing composer.json dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,10 @@
     "description": "Messenger bridge for Docplanner messaging standard",
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "symfony/messenger": "^4.4 || ^5.0 || ^6.0"
+        "symfony/messenger": "^4.4 || ^5.0 || ^6.0",
+        "symfony/http-kernel": "*",
+        "symfony/dependency-injection": "*",
+        "symfony/serializer": "*"
     },
     "authors": [
         {
@@ -17,5 +20,8 @@
         "psr-4": {
             "DanielKorytek\\MessengerBridgeBundle\\": "src"
         }
+    },
+    "suggest": {
+        "symfony/amqp-messenger": "Required since symfony/messenger:^5.1"
     }
 }

--- a/src/MessengerBridgeBundle.php
+++ b/src/MessengerBridgeBundle.php
@@ -6,10 +6,11 @@ namespace DanielKorytek\MessengerBridgeBundle;
 
 use DanielKorytek\MessengerBridgeBundle\DependencyInjection\MessengerBridgeExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 final class MessengerBridgeBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new MessengerBridgeExtension();
     }


### PR DESCRIPTION
Since Symfony 6, classes extending `Bundle::getContainerExtension()` have to return `?ExtensionInterface`
```
Compile Error: Declaration of DanielKorytek\MessengerBridgeBundle\MessengerBridgeBundle::getContainerExtension() must be compatible with Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension(): ?Symfony\Component\DependencyInjection\Extension\ExtensionInterface"
```

Additionally, added missing dependencies to `composer.json` that were required anyway due to their usage in the code