### PR TITLE
Remove native type deprecation in MessengerBridgeExtension

### DIFF
--- a/src/DependencyInjection/MessengerBridgeExtension.php
+++ b/src/DependencyInjection/MessengerBridgeExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 final class MessengerBridgeExtension extends Extension
 {
-	public function load(array $configs, ContainerBuilder $container)
+	public function load(array $configs, ContainerBuilder $container): void
 	{
 		$loader = new YamlFileLoader($container, new FileLocator(
 			__DIR__ . '/../Resources/config'


### PR DESCRIPTION
To remove the deprecation notice, we need to set the return type explicitly. Otherwise, we see this message in deprecation log:

> Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "DanielKorytek\MessengerBridgeBundle\DependencyInjection\MessengerBridgeExtension" now to avoid errors or add an explicit @return annotation to suppress this message.