### PR TITLE
Fix PHP 8.4 deprecated notice DocplannerEnvelope::__construct()

### DIFF
--- a/src/Message/Envelope/DocplannerEnvelope.php
+++ b/src/Message/Envelope/DocplannerEnvelope.php
@@ -18,7 +18,7 @@ final class DocplannerEnvelope
 	 */
 	private $payload;
 
-	public function __construct(string $type, string $payload = null)
+	public function __construct(string $type, ?string $payload = null)
 	{
 		$this->type    = $type;
 		$this->payload = $payload;


### PR DESCRIPTION
Deprecated:  DanielKorytek\MessengerBridgeBundle\Message\Envelope\DocplannerEnvelope::__construct(): Implicitly marking parameter $payload as nullable is deprecated, the explicit nullable type must be used instead